### PR TITLE
Fix gif rendering of models with actions

### DIFF
--- a/stormvogel/extensions/gifs.py
+++ b/stormvogel/extensions/gifs.py
@@ -41,7 +41,7 @@ def render_model_gif(
     for i in range(1, min(max_length, len(path) + 1)):
         state = path.get_step(i)
         if not isinstance(state, stormvogel.model.State):
-            state = state[i]
+            state = state[1]
         frames.append(state_to_image(state))  # type: ignore
 
     os.makedirs("gifs", exist_ok=True)

--- a/stormvogel/simulator.py
+++ b/stormvogel/simulator.py
@@ -40,7 +40,7 @@ class Path:
             state = self.path[step]
             assert isinstance(state, stormvogel.model.State)
             return state
-        if self.supports_actions():
+        if self.model.supports_actions():
             t = self.path[step]
             assert (
                 isinstance(t, tuple)


### PR DESCRIPTION
When rendering a model mith actions, paths are action state pairs. However, they where indexed with the iterator over the length of the path instead of just `1`.