### PR TITLE
Made stormpy integration more robust

### DIFF
--- a/stormvogel/stormpy_utils/convert_results.py
+++ b/stormvogel/stormpy_utils/convert_results.py
@@ -25,9 +25,9 @@ def convert_scheduler_to_stormvogel(
 def convert_model_checking_result(
     model: stormvogel.model.Model,
     stormpy_result: Union[
-        "stormpy.core.ExplicitQuantitativeCheckResult",
-        "stormpy.core.ExplicitQualitativeCheckResult",
-        "stormpy.core.ExplicitParametricQuantitativeCheckResult",
+        "stormpy.ExplicitQuantitativeCheckResult",
+        "stormpy.ExplicitQualitativeCheckResult",
+        "stormpy.ExplicitParametricQuantitativeCheckResult",
     ],
     with_scheduler: bool = True,
 ) -> stormvogel.result.Result | None:
@@ -37,9 +37,8 @@ def convert_model_checking_result(
     assert stormpy is not None
 
     if (
-        type(stormpy_result) == stormpy.core.ExplicitQuantitativeCheckResult
-        or type(stormpy_result)
-        == stormpy.core.ExplicitParametricQuantitativeCheckResult
+        type(stormpy_result) == stormpy.ExplicitQuantitativeCheckResult
+        or type(stormpy_result) == stormpy.ExplicitParametricQuantitativeCheckResult
     ):
         if stormpy_result.has_scheduler and with_scheduler:
             stormvogel_result = stormvogel.result.Result(
@@ -60,7 +59,7 @@ def convert_model_checking_result(
                     for (index, value) in enumerate(stormpy_result.get_values())
                 },
             )
-    elif type(stormpy_result == stormpy.core.ExplicitQualitativeCheckResult):
+    elif type(stormpy_result == stormpy.ExplicitQualitativeCheckResult):
         values = {i: stormpy_result.at(i) for i in range(0, len(model.states))}
         if stormpy_result.has_scheduler and with_scheduler:
             stormvogel_result = stormvogel.result.Result(

--- a/stormvogel/stormpy_utils/mapping.py
+++ b/stormvogel/stormpy_utils/mapping.py
@@ -25,17 +25,17 @@ def value_to_stormpy(
         terms = []
         for exponent, coefficient in polynomial.terms.items():
             if coefficient != 0:
-                stormpy_term = stormpy.pycarl.cln.cln.Term(
-                    stormpy.pycarl.cln.cln.Rational(coefficient)
+                stormpy_term = stormpy.pycarl.cln.Term(
+                    stormpy.pycarl.cln.Rational(coefficient)
                 )
                 assert isinstance(exponent, tuple)
                 for index, exp in enumerate(exponent):
                     for i in range(exp):
                         stormpy_term *= variables[index]
                 terms.append(stormpy_term)
-        polynomial = stormpy.pycarl.cln.cln.Polynomial(terms)
+        polynomial = stormpy.pycarl.cln.Polynomial(terms)
         factorized_polynomial = stormpy.pycarl.cln.FactorizedPolynomial(
-            polynomial, stormpy.pycarl.cln.cln._FactorizationCache()
+            polynomial, stormpy.pycarl.cln.factorization_cache
         )
         return factorized_polynomial
 
@@ -44,10 +44,10 @@ def value_to_stormpy(
 
         # we have a special case for floats as they are not just a specific case of a polynomial in stormvogel
         if isinstance(value, float):
-            rational = stormpy.pycarl.cln.cln.Rational(value)
-            polynomial = stormpy.pycarl.cln.cln.Polynomial(rational)
+            rational = stormpy.pycarl.cln.Rational(value)
+            polynomial = stormpy.pycarl.cln.Polynomial(rational)
             factorized_polynomial = stormpy.pycarl.cln.FactorizedPolynomial(
-                polynomial, stormpy.pycarl.cln.cln._FactorizationCache()
+                polynomial, stormpy.pycarl.cln.factorization_cache
             )
             factorized_rational = stormpy.pycarl.cln.FactorizedRationalFunction(
                 factorized_polynomial


### PR DESCRIPTION
Replaced private API calls with public ones:
- use `stormpy` instead of `stormpy.core`
- use `stormpy.pycarl.cln` instead of `stormpy.pycarl.cln.cln`
- use `stormpy.pycarl.cln.factorization_cache` instead of `stormpy.pycarl.cln.cln._FactorizationCache()`