### PR TITLE
Add LTS Layout that hides probabilities

### DIFF
--- a/docs/2-Visualization/layouts/car.json
+++ b/docs/2-Visualization/layouts/car.json
@@ -146,6 +146,7 @@
     "width": 1
   },
   "numbers": {
+    "visible": true,
     "fractions": true,
     "digits": 5,
     "denominator_limit": 1000

--- a/stormvogel/layout.py
+++ b/stormvogel/layout.py
@@ -166,7 +166,7 @@ def DEFAULT():
 
 def EXPLORE():
     default = DEFAULT()
-    default.layout.layout["misc"]["explore"] = True
+    default.layout["misc"]["explore"] = True
     return default
 
 
@@ -174,3 +174,9 @@ def SV():
     return Layout(
         os.path.join(PACKAGE_ROOT_DIR, "layouts/sv.json"), path_relative=False
     )
+
+
+def LTS():
+    default = DEFAULT()
+    default.layout["numbers"]["visible"] = False
+    return default

--- a/stormvogel/layouts/default.json
+++ b/stormvogel/layouts/default.json
@@ -54,6 +54,7 @@
     "width": 1
   },
   "numbers": {
+    "visible": true,
     "fractions": true,
     "digits": 5,
     "denominator_limit": 1000

--- a/stormvogel/layouts/schema.json
+++ b/stormvogel/layouts/schema.json
@@ -99,6 +99,10 @@
   },
   "numbers": {
     "__collapse": true,
+    "visible": {
+      "__description": "Show numbers",
+      "__widget": "Checkbox"
+    },
     "fractions": {
       "__description": "Fractions",
       "__widget": "Checkbox"

--- a/stormvogel/visualization.py
+++ b/stormvogel/visualization.py
@@ -130,6 +130,8 @@ class VisualizationBase:
 
     def _format_number(self, n: stormvogel.model.Value) -> str:
         """Call number_to_string in model.py while accounting for the settings specified in the layout object."""
+        if self.layout.layout["numbers"]["visible"] is False:
+            return ""
         return stormvogel.model.value_to_string(
             n,
             self.layout.layout["numbers"]["fractions"],

--- a/tests/saved_test_layout.json
+++ b/tests/saved_test_layout.json
@@ -54,6 +54,7 @@
     "width": 1
   },
   "numbers": {
+    "visible": true,
     "fractions": true,
     "digits": 5,
     "denominator_limit": 1000


### PR DESCRIPTION
Fixes one use-case of https://github.com/stormchecker/stormvogel/issues/452 (but does not explicitly add an LTS type yet)